### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,10 @@
 # tag the commit, and push it straight to main.
 
 name: production-build
+
 permissions:
   contents: read
+
 on:
   pull_request:
     types: [closed]
@@ -77,15 +79,15 @@ jobs:
 
       - name: Bump version
         run: |
-          node --version
-          pnpm --version
+          echo "Node.js: $(node --version)"
+          echo "Pnpm: $(pnpm --version)"
           # We pull the type of version increase from the PR labels
           operation=$(echo '${{toJSON(github.event.pull_request.labels.*.name)}}' | jq '.[] | select(. as $item | ["major", "minor", "patch"] | contains([$item]))')
-          echo "Creating a new ${operation} version"
+          echo "Creating a new ${operation//\"/} version"
           cd packages/fe
-          new_version=$(npm version ${operation//\"/})
-          new_version_short=$(cat package.json | jq ".version")
+          npm version --no-git-tag-version ${operation//\"/}
+          new_version=$(cat package.json | jq ".version")
           git add .
-          git commit -m ${new_version_short//\"/}
-          git tag -a ${new_version} -m "${new_version}"
+          git commit -m "${new_version}"
+          git tag -a v${new_version} -m "v${new_version}"
           git push --tags https://x-access-token:${{ steps.generate_token.outputs.token }}@github.com/${{ github.repository }}.git HEAD:${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@
 # tag the commit, and push it straight to main.
 
 name: production-build
+permissions:
+  contents: read
 on:
   pull_request:
     types: [closed]

--- a/packages/fe/package.json
+++ b/packages/fe/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dist": "cp packages/fe/package.json docs/",
-    "versions": "pnpm run dist && git status && git add -A ../../docs"
+    "version": "echo 'This is a different test' > ../../docs/index.html"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Potential fix for [https://github.com/tatablack/test-gha/security/code-scanning/1](https://github.com/tatablack/test-gha/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimal permissions required for the `GITHUB_TOKEN`. Based on the operations performed in the workflow, the `contents: read` permission is sufficient, as the workflow does not use the `GITHUB_TOKEN` for write operations. This change will ensure that the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
